### PR TITLE
Active flag fix

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -30,17 +30,17 @@ __int64 hkGetOutfitIDFromItemID(__int64 item_base, int item_ID)
 	switch (item_ID)
 	{
 	case NieR::ItemId::ITEM_2P_BODY:    //2P
-		return 5;
+		return NieR::OutfitId::OUTFIT_2B_2P_BODY;
 	case NieR::ItemId::ITEM_2B_KIMONO:  //2B Kimono
-		return 6;
+		return NieR::OutfitId::OUTFIT_2B_KIMONO;
 	case NieR::ItemId::ITEM_9P_BODY:    //9P
-		return 3;
+		return NieR::OutfitId::OUTFIT_9S_9P_BODY;
 	case NieR::ItemId::ITEM_9S_KIMONO:  //9S Kimono
-		return 4;
+		return NieR::OutfitId::OUTFIT_9S_KIMONO;
 	case NieR::ItemId::ITEM_P2_BODY:    //P2
-		return 7;
+		return NieR::OutfitId::OUTFIT_A2_P2_BODY;
 	case NieR::ItemId::ITEM_A2_KIMONO:  //A2 Kimono
-		return 8;
+		return NieR::OutfitId::OUTFIT_A2_KIMONO;
 	}
 
 	return NieR::GetOutfitIDFromItemID(item_base, item_ID);
@@ -112,9 +112,9 @@ __int64 hkUpdateEquippedActive(__int64 a1, __int64 item_id, int currentPlayer)
 
 		/// @note NOTE: Since GetOutfitIDFromItemID() returns unexpected outfit IDs for the Switch DLC outfits
 		/// we need to manually return the expected outfit IDs based on item ID for the new Switch DLC outfits
-		/// and call the original function for every other outfit. We avoid hooking GetOutfitIDFromItemID()
-		/// because there may be some additional logic that is performed in the original function that could
-		/// cause the new Switch DLC outfits to fail the outfit validation at the top of this function.
+		/// and call the original function for every other outfit. I'm choosing not to hook GetOutfitIDFromItemID()
+		/// because the original function could potentially be used somewhere else in the executable where it expects
+		/// the strange outfit IDs.
 		int outfitId = (item_id == NieR::ItemId::ITEM_2P_BODY)   ? NieR::OutfitId::OUTFIT_2B_2P_BODY :
 					   (item_id == NieR::ItemId::ITEM_2B_KIMONO) ? NieR::OutfitId::OUTFIT_2B_KIMONO :
 					   (item_id == NieR::ItemId::ITEM_9P_BODY)   ? NieR::OutfitId::OUTFIT_9S_9P_BODY :
@@ -372,16 +372,16 @@ __int64 hkSetEquippedFromPause(__int64 a1, int item_id)
 		NieR::PlayerModelInfo* v9 = (NieR::PlayerModelInfo*)v7;
 
 		//Workaround
-		if (v9->outfitEquipped == 4)
+		if (v9->outfitEquipped == NieR::OutfitId::OUTFIT_2B_2P_BODY)
 		{
-			NieR::SetOutfitFromPause(v9, 0, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_2B_NORMAL, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
 
 		if (v7)
 		{
-			NieR::SetOutfitFromPause(v9, 4, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_2B_2P_BODY, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
@@ -395,16 +395,16 @@ __int64 hkSetEquippedFromPause(__int64 a1, int item_id)
 		NieR::PlayerModelInfo* v9 = (NieR::PlayerModelInfo*)v7;
 
 		//Workaround
-		if (v9->outfitEquipped == 5)
+		if (v9->outfitEquipped == NieR::OutfitId::OUTFIT_2B_KIMONO)
 		{
-			NieR::SetOutfitFromPause(v9, 0, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_2B_NORMAL, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
 
 		if (v7)
 		{
-			NieR::SetOutfitFromPause(v9, 5, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_2B_KIMONO, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
@@ -418,16 +418,16 @@ __int64 hkSetEquippedFromPause(__int64 a1, int item_id)
 		NieR::PlayerModelInfo* v9 = (NieR::PlayerModelInfo*)v7;
 
 		//Workaround
-		if (v9->outfitEquipped == 2)
+		if (v9->outfitEquipped == NieR::OutfitId::OUTFIT_9S_9P_BODY)
 		{
-			NieR::SetOutfitFromPause(v9, 0, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_9S_NORMAL, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
 
 		if (v7)
 		{
-			NieR::SetOutfitFromPause(v9, 2, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_9S_9P_BODY, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
@@ -441,16 +441,16 @@ __int64 hkSetEquippedFromPause(__int64 a1, int item_id)
 		NieR::PlayerModelInfo* v9 = (NieR::PlayerModelInfo*)v7;
 
 		//Workaround
-		if (v9->outfitEquipped == 3)
+		if (v9->outfitEquipped == NieR::OutfitId::OUTFIT_9S_KIMONO)
 		{
-			NieR::SetOutfitFromPause(v9, 0, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_9S_NORMAL, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
 
 		if (v7)
 		{
-			NieR::SetOutfitFromPause(v9, 3, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_9S_KIMONO, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
@@ -464,16 +464,16 @@ __int64 hkSetEquippedFromPause(__int64 a1, int item_id)
 		NieR::PlayerModelInfo* v9 = (NieR::PlayerModelInfo*)v7;
 
 		//Workaround
-		if (v9->outfitEquipped == 3)
+		if (v9->outfitEquipped == NieR::OutfitId::OUTFIT_A2_P2_BODY)
 		{
-			NieR::SetOutfitFromPause(v9, 0, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_A2_NORMAL, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
 
 		if (v7)
 		{
-			NieR::SetOutfitFromPause(v9, 3, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_A2_P2_BODY, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
@@ -487,16 +487,16 @@ __int64 hkSetEquippedFromPause(__int64 a1, int item_id)
 		NieR::PlayerModelInfo* v9 = (NieR::PlayerModelInfo*)v7;
 
 		//Workaround
-		if (v9->outfitEquipped == 2)
+		if (v9->outfitEquipped == NieR::OutfitId::OUTFIT_A2_KIMONO)
 		{
-			NieR::SetOutfitFromPause(v9, 0, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_A2_NORMAL, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
 
 		if (v7)
 		{
-			NieR::SetOutfitFromPause(v9, 2, 1);
+			NieR::SetOutfitFromPause(v9, NieR::OutfitId::OUTFIT_A2_KIMONO, 1);
 			*(int*)(modBase + 0x13fd4ac) = 1;
 			return 1;
 		}
@@ -833,7 +833,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 			}
 
 
-			if ((pPlayerModelInfo->outfitEquipped) != 1)
+			if ((pPlayerModelInfo->outfitEquipped) != NieR::OutfitId::OUTFIT_A2_DESTROYER)
 			{
 				if ((pPlayerModelInfo->dwordShowPants) == 0)
 				{
@@ -843,7 +843,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 					SetMeshInvisible(pPlayerModelInfo, "NS_P2_Cloth");
 				}
 
-				if (pPlayerModelInfo->outfitEquipped == 2)
+				if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_A2_KIMONO)
 				{
 					SetMeshVisible(pPlayerModelInfo, "NS_KIMONO_Broken");
 				}

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -1,7 +1,7 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
+#include <iostream>
 #include "minhook/include/MinHook.h"
 #include "niera/NierA.h"
-#include <iostream>
 
 //Stinky globals :)
 uintptr_t modBase = NULL;
@@ -52,13 +52,15 @@ __int64 hkUpdateEquippedActive(__int64 a1, __int64 item_id, int currentPlayer)
 
 	const char* resolvedName = "";
 	// Remember we hook this validate function, so this calls the original, which actually jumps to our hook
-	if (!NieR::OriginalValidateNonCharacterSpecificEquippable(modBase + 0x133b510, item_id) || currentPlayer > 2 || item_id == -1)
+	if (!NieR::OriginalValidateNonCharacterSpecificEquippable(modBase + 0x133b510, item_id) ||
+		currentPlayer > NieR::PlayerId::PID_A2 ||
+		item_id == -1)
 	{
 		return 0;
 	}
 
 	//2B
-	if (currentPlayer == 0)
+	if (currentPlayer == NieR::PlayerId::PID_2B)
 	{
 		resolvedName = NieR::ResolveNameFromItemID(modBase + 0x133b510, item_id);
 		if (strcmp(resolvedName, "item_uq_changeArmour1") &&
@@ -72,7 +74,7 @@ __int64 hkUpdateEquippedActive(__int64 a1, __int64 item_id, int currentPlayer)
 	}
 
 	//9S
-	else if (currentPlayer == 1)
+	else if (currentPlayer == NieR::PlayerId::PID_9S)
 	{
 		resolvedName = NieR::ResolveNameFromItemID(modBase + 0x133b510, item_id);
 		if (strcmp(resolvedName, "item_uq_dlcCloth2") &&
@@ -84,7 +86,7 @@ __int64 hkUpdateEquippedActive(__int64 a1, __int64 item_id, int currentPlayer)
 	}
 
 	//A2
-	else if (currentPlayer == 2)
+	else if (currentPlayer == NieR::PlayerId::PID_A2)
 	{
 		resolvedName = NieR::ResolveNameFromItemID(modBase + 0x133b510, item_id);
 		if (strcmp(resolvedName, "item_uq_dlcCloth3") &&
@@ -123,11 +125,15 @@ __int64 hkValidateDLCArmor(__int64 item_base, __int64 item_id, int currentPlayer
 	const char* resolved_name = "";
 	const char* expected_name = "";
 
-	if (item_id == -1 || currentPlayer <= -1 || currentPlayer > 2)
+	if (item_id == -1 ||
+		currentPlayer <= NieR::PlayerId::PID_INVALID ||
+		currentPlayer > NieR::PlayerId::PID_A2)
+	{
 		return 0i64;
+	}
 
 	//2B
-	if (currentPlayer == 0)
+	if (currentPlayer == NieR::PlayerId::PID_2B)
 	{
 		resolved_name = (const char*)NieR::ResolveNameFromItemID(item_base, item_id);
 		if (!strcmp(resolved_name, "item_uq_changeArmour1"))
@@ -147,7 +153,7 @@ __int64 hkValidateDLCArmor(__int64 item_base, __int64 item_id, int currentPlayer
 	}
 
 	//9S
-	else if (currentPlayer == 1)
+	else if (currentPlayer == NieR::PlayerId::PID_9S)
 	{
 		resolved_name = (const char*)NieR::ResolveNameFromItemID(item_base, item_id);
 		if (!strcmp(resolved_name, "item_uq_dlcOutfit3"))	//9P
@@ -161,7 +167,7 @@ __int64 hkValidateDLCArmor(__int64 item_base, __int64 item_id, int currentPlayer
 	}
 
 	//A2
-	else if (currentPlayer == 2)
+	else if (currentPlayer == NieR::PlayerId::PID_A2)
 	{
 		resolved_name = (const char*)NieR::ResolveNameFromItemID(item_base, item_id);
 		if (!strcmp(resolved_name, "item_uq_dlcOutfit5"))	//P2
@@ -717,7 +723,8 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 
 
 	//A2
-	if (((pPlayerModelInfo->currentPlayer) != 0x10000 || ((pPlayerModelInfo->currentPlayer) == 0x10000 && (pPlayerModelInfo->dwordisDestructed) == 0)))
+	if (pPlayerModelInfo->currentPlayer != 0x10000 ||
+		(pPlayerModelInfo->currentPlayer == 0x10000 && pPlayerModelInfo->dwordisDestructed == 0))
 	{
 		const char* extra = "";
 		if ((pPlayerModelInfo->currentPlayer) - 0x10100 <= 1)

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -57,6 +57,7 @@ __int64 hkUpdateEquippedActive(__int64 a1, __int64 item_id, int currentPlayer)
 	//std::cout << "ItemID: " << item_id << " ResolvedName: " << NieR::ResolveNameFromItemID(modBase + 0x133b510, item_id) << "\n";
 
 	const char* resolvedName = "";
+	// Remember we hook this validate function, so this function pointer jumps to our hook
 	if (!NieR::ValidateNonCharacterSpecificEquippable(modBase + 0x133b510, item_id) ||
 		currentPlayer > NieR::PlayerId::PID_A2 ||
 		item_id == -1)

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -514,7 +514,9 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 	{
 		NieR::SetDrawBasePlayerMeshes((NieR::CModelWork*)&pPlayerModelInfo->gap0[0x390], 1);
 		__int64 thing = (__int64)pPlayerModelInfo;
-		if (pPlayerModelInfo->outfitEquipped == 1) //kaine outfit
+		
+		//kaine outfit
+		if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_2B_KAINE)
 		{
 			SetMeshInvisible(pPlayerModelInfo, "Armor_Body");
 			SetMeshInvisible(pPlayerModelInfo, "Armor_Head");
@@ -537,15 +539,15 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 			SetMeshInvisible(pPlayerModelInfo, "Feather");
 			SetMeshInvisible(pPlayerModelInfo, "Skirt");
 		}
-
-		else if (pPlayerModelInfo->outfitEquipped == 2) //full armor
+		//full armor
+		else if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_2B_ARMOR_A)
 		{
 			NieR::SetDrawBasePlayerMeshes((NieR::CModelWork*)&pPlayerModelInfo->gap0[0x390], 0);
 			SetMeshVisible(pPlayerModelInfo, "Armor_Body");
 			SetMeshVisible(pPlayerModelInfo, "Armor_Head");
 		}
-
-		else if (pPlayerModelInfo->outfitEquipped == 3)	//just armor body
+		//just armor body
+		else if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_2B_ARMOR_B)
 		{
 			SetMeshInvisible(pPlayerModelInfo, "Armor_Head");
 			SetMeshInvisible(pPlayerModelInfo, "DLC_Body");
@@ -570,8 +572,8 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 			SetMeshInvisible(pPlayerModelInfo, "NS_2P_Skirt");
 			v15 = "Broken";
 		}
-
-		else if (pPlayerModelInfo->outfitEquipped == 4)	//2P
+		//2P
+		else if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_2B_2P_BODY)
 		{
 			// We could do this nicely and do activations instead of deactivations but it doesn't play as nice with the other code
 			SetMeshInvisible(pPlayerModelInfo, "Armor_Body");
@@ -590,8 +592,8 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 			SetMeshInvisible(pPlayerModelInfo, "Feather");
 			SetMeshInvisible(pPlayerModelInfo, "Skirt");
 		}
-
-		else if (pPlayerModelInfo->outfitEquipped == 5) //Kimono
+		//Kimono
+		else if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_2B_KIMONO)
 		{
 			SetMeshInvisible(pPlayerModelInfo, "Armor_Body");
 			SetMeshInvisible(pPlayerModelInfo, "Armor_Head");
@@ -611,8 +613,8 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 			SetMeshInvisible(pPlayerModelInfo, "Feather");
 			SetMeshInvisible(pPlayerModelInfo, "Skirt");
 		}
-
-		else  // normal
+		//Normal
+		else
 		{
 			SetMeshInvisible(pPlayerModelInfo, "Armor_Body");
 			SetMeshInvisible(pPlayerModelInfo, "Armor_Head");
@@ -753,7 +755,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 		{
 			NieR::SetDrawBasePlayerMeshes((NieR::CModelWork*)(&pPlayerModelInfo->gap0[0x390]), 1);
 			// Destroyer Outfit
-			if ((pPlayerModelInfo->outfitEquipped) == 1)
+			if ((pPlayerModelInfo->outfitEquipped) == NieR::OutfitId::OUTFIT_A2_DESTROYER)
 			{
 				SetMeshInvisible(pPlayerModelInfo, "Body");
 				SetMeshInvisible(pPlayerModelInfo, "Cloth");
@@ -767,7 +769,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 			}
 
 			// YoRHA Uniform Prototype
-			else if (pPlayerModelInfo->outfitEquipped == 2)
+			else if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_A2_KIMONO)
 			{
 				SetMeshInvisible(pPlayerModelInfo, "Body");
 				SetMeshInvisible(pPlayerModelInfo, "Cloth");
@@ -781,7 +783,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 			}
 
 			// P2's Body Replica
-			else if (pPlayerModelInfo->outfitEquipped == 3)
+			else if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_A2_P2_BODY)
 			{
 				SetMeshInvisible(pPlayerModelInfo, "Body");
 				SetMeshInvisible(pPlayerModelInfo, "Cloth");
@@ -868,7 +870,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 		NieR::SetDrawBasePlayerMeshes((NieR::CModelWork*)(&pPlayerModelInfo->gap0[0x390]), 1);
 
 		//Normal
-		if (pPlayerModelInfo->outfitEquipped == 0)
+		if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_9S_NORMAL)
 		{
 			SetMeshInvisible(pPlayerModelInfo, "DLC_Pants");
 			SetMeshInvisible(pPlayerModelInfo, "DLC_Body");
@@ -901,7 +903,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 		}
 
 		//Young Man Outfit
-		if (pPlayerModelInfo->outfitEquipped == 1)
+		if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_9S_YOUNG_MAN)
 		{
 			SetMeshInvisible(pPlayerModelInfo, "Pants");
 			SetMeshInvisible(pPlayerModelInfo, "Body");
@@ -934,7 +936,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 		}
 
 		//9P (White 9S)
-		if (pPlayerModelInfo->outfitEquipped == 2)
+		if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_9S_9P_BODY)
 		{
 			SetMeshInvisible(pPlayerModelInfo, "Pants");
 			SetMeshInvisible(pPlayerModelInfo, "Body");
@@ -965,7 +967,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 		}
 
 		//Kimono
-		else if (pPlayerModelInfo->outfitEquipped == 3)
+		else if (pPlayerModelInfo->outfitEquipped == NieR::OutfitId::OUTFIT_9S_KIMONO)
 		{
 			SetMeshInvisible(pPlayerModelInfo, "Pants");
 			SetMeshInvisible(pPlayerModelInfo, "Body");

--- a/dllmain.h
+++ b/dllmain.h
@@ -1,0 +1,37 @@
+#ifndef _NASA_DLL_MAIN_H_
+#define _NASA_DLL_MAIN_H_
+
+#include "niera/NierA.h"
+
+// Hooks
+__int64 hkSetAccessory(__int64 a1, const char* meshGroup, int accessoryFileID, __int64 pUnk); // Not currently hooked
+
+__int64 hkGetOutfitIDFromItemID(__int64 item_base, int item_ID); // Not currently hooked
+
+__int64 hkUpdateEquippedActive(__int64 a1, __int64 item_id, int currentPlayer);
+
+bool hkValidateAccessory(__int64 item_base, __int64 item_id, int currentPlayer); // Not yet implemented
+
+__int64 hkValidateDLCArmor(__int64 item_base, __int64 item_id, int currentPlayer);
+
+__int64 hkValidateNonSpecificCharacterEquippable(__int64 item_base, int item_id);
+
+__int64 hkUpdateAccessoryOnUnpause(NieR::PlayerModelInfo* pPlayerModelInfo); // Not currently hooked
+
+__int64 hkSetEquippedFromPause(__int64 a1, int item_id);
+
+__int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelInfo);
+
+// Mesh helpers
+void SetMeshInvisible(NieR::PlayerModelInfo* pPlayerModelInfo, const char* mesh_name);
+
+void SetMeshVisible(NieR::PlayerModelInfo* pPlayerModelInfo, const char* mesh_name);
+
+// Other helpers
+__int64* lambda_meme(__int64* a1, int* a2);
+
+void InitializeFunctionPointers();
+
+void ConsoleSetup();
+
+#endif

--- a/niera/NierA.h
+++ b/niera/NierA.h
@@ -201,4 +201,38 @@ namespace NieR
 		PID_9S      = 1,
 		PID_A2      = 2
 	};
+
+	enum ItemId : int
+	{
+		ITEM_INVALID   = -1,
+		ITEM_2P_BODY   = 81,
+		ITEM_2B_KIMONO = 82,
+		ITEM_9P_BODY   = 83,
+		ITEM_9S_KIMONO = 84,
+		ITEM_P2_BODY   = 85,
+		ITEM_A2_KIMONO = 86
+	};
+
+	enum OutfitId : int
+	{
+		// 2B Outfits
+		OUTFIT_2B_NORMAL  = 0,
+		OUTFIT_2B_KAINE   = 1,
+		OUTFIT_2B_ARMOR_A = 2,
+		OUTFIT_2B_ARMOR_B = 3,
+		OUTFIT_2B_2P_BODY = 4,
+		OUTFIT_2B_KIMONO  = 5,
+
+		// 9S Outfits
+		OUTFIT_9S_NORMAL    = 0,
+		OUTFIT_9S_YOUNG_MAN = 1,
+		OUTFIT_9S_9P_BODY   = 2,
+		OUTFIT_9S_KIMONO    = 3,
+
+		// A2 Outfits
+		OUTFIT_A2_NORMAL    = 0,
+		OUTFIT_A2_DESTROYER = 1,
+		OUTFIT_A2_KIMONO    = 2,
+		OUTFIT_A2_P2_BODY   = 3
+	};
 }

--- a/niera/NierA.h
+++ b/niera/NierA.h
@@ -192,4 +192,13 @@ namespace NieR
 	extern FnUpdateEquippedActive OriginalUpdateEquippedActive;
 	extern FnValidateDLCArmor OriginalValidateDLCArmor;
 	extern FnSetMeshToGroup OriginalSetMeshToGroup;
+
+	// Enum defs
+	enum PlayerId : int
+	{
+		PID_INVALID = -1,
+		PID_2B      = 0,
+		PID_9S      = 1,
+		PID_A2      = 2
+	};
 }


### PR DESCRIPTION
Fixes active flagging issue with Switch DLC outfits added to the game. New outfits will now display "Active" when equipped and nothing when unequipped.

Unequipped DLC Outfit:
![A2_no_outfit_active](https://github.com/xxk-i/NASA/assets/28588123/a9d8e25b-2e67-4c57-acf4-36fd106812d2)
![A2_normal_outfit](https://github.com/xxk-i/NASA/assets/28588123/6044067a-0c87-4fa6-817c-a90c9f145fb3)

Equipped DLC Outfit:
![A2_Kimono_active](https://github.com/xxk-i/NASA/assets/28588123/18f2d74c-7ccd-4262-bd1f-6ee2e897a22d)
![A2_Kimono_equipped](https://github.com/xxk-i/NASA/assets/28588123/affdf6c5-f901-4c16-abf1-5cb7b48e8277)
