### PR TITLE
Fixed 2B multi-mesh issue seen in chapter 11.1

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -708,9 +708,10 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 		}
 		else
 		{
-			NieR::SetDrawBasePlayerMeshes((NieR::CModelWork*)(&pPlayerModelInfo->gap0[0x390]), 1);
+			// This section is entered when playing as 2B during chapter 11
 			if ((pPlayerModelInfo->dword178E0) == 0)
 			{
+				NieR::SetDrawBasePlayerMeshes((NieR::CModelWork*)(&pPlayerModelInfo->gap0[0x390]), 1);
 				SetMeshInvisible(pPlayerModelInfo, "Armor_Head");
 				SetMeshInvisible(pPlayerModelInfo, "DLC_Body");
 				SetMeshInvisible(pPlayerModelInfo, "DLC_Skirt");
@@ -736,7 +737,7 @@ __int64 __fastcall HkManageMeshVisibilites(NieR::PlayerModelInfo* pPlayerModelIn
 			}
 			else
 			{
-				NieR::SetDrawBasePlayerMeshes((NieR::CModelWork*)(&pPlayerModelInfo->gap0[0x390]), 1);
+				NieR::SetDrawBasePlayerMeshes((NieR::CModelWork*)(&pPlayerModelInfo->gap0[0x390]), 0);
 				SetMeshVisible(pPlayerModelInfo, "Armor_Body");
 				SetMeshVisible(pPlayerModelInfo, "Armor_Head");
 			}


### PR DESCRIPTION
This branch fixes the issue #3 by fixing the value being passed into a SetDrawBasePlayerMeshes() call.

Comparison between decomp and lines of code currently on main:
![2B-heavy-armor-ch-11-section-decomp](https://github.com/xxk-i/NASA/assets/28588123/3b98b2a4-ffa9-4c88-9046-73ad8e57b23b)
![2B-heavy-armor-ch-11-section-current-main](https://github.com/xxk-i/NASA/assets/28588123/bc157204-3b9a-42e7-9bf0-349168d38fdf)

Results:
![2B_chapter_11](https://github.com/xxk-i/NASA/assets/28588123/c1625c47-ecbc-4d6b-87c0-2abc07d7ea4c)
